### PR TITLE
Simplify 'while' test for Reconstruct SSA path

### DIFF
--- a/newlang/hckernel/tests/Transforms/reconstruct-ssa.mlir
+++ b/newlang/hckernel/tests/Transforms/reconstruct-ssa.mlir
@@ -107,7 +107,7 @@ py_ir.module {
 // -----
 
 // CHECK-LABEL: py_ir.module
-//       CHECK:  %2 = py_ir.func "func"
+//       CHECK:  py_ir.func
 //       CHECK:    cf.br ^[[CONDBR:.*]](%{{.*}})
 //       CHECK:  ^[[CONDBR]](%[[BV1:.*]]: [[BV1T:.*]]):
 //       CHECK:    %[[COND:.*]] = py_ir.cast %[[BV1]] : [[BV1T]] to i1
@@ -120,24 +120,22 @@ py_ir.module {
 //       CHECK:    py_ir.return
 py_ir.module {
   %0 = py_ir.constant 1 : i64
-  %1 = py_ir.constant 0 : i64
-  %2 = py_ir.func "func" -> !py_ir.undefined {
-    py_ir.storevar "A" %1 : i64
+  %1 = py_ir.func "func" -> !py_ir.undefined {
     cf.br ^bb1
   ^bb1:  // 2 preds: ^bb0, ^bb2
-    %5 = py_ir.loadvar "A" : !py_ir.undefined
-    %6 = py_ir.cast %5 : !py_ir.undefined to i1
-    cf.cond_br %6, ^bb2, ^bb3
+    %4 = py_ir.loadvar "A" : !py_ir.undefined
+    %5 = py_ir.cast %4 : !py_ir.undefined to i1
+    cf.cond_br %5, ^bb2, ^bb3
   ^bb2:  // pred: ^bb1
-    %7 = py_ir.loadvar "A" : !py_ir.undefined
-    %8 = py_ir.binop %7 : !py_ir.undefined add %0 : i64 -> !py_ir.undefined
-    py_ir.storevar "A" %8 : !py_ir.undefined
+    %6 = py_ir.loadvar "A" : !py_ir.undefined
+    %7 = py_ir.binop %6 : !py_ir.undefined add %0 : i64 -> !py_ir.undefined
+    py_ir.storevar "A" %7 : !py_ir.undefined
     cf.br ^bb1
   ^bb3:  // pred: ^bb1
-    %9 = py_ir.none
-    py_ir.return %9 : none
+    %8 = py_ir.none
+    py_ir.return %8 : none
   }
-  py_ir.storevar "func" %2 : !py_ir.undefined
-  %3 = py_ir.loadvar "func" : !py_ir.undefined
-  %4 = py_ir.call %3 : !py_ir.undefined  () -> !py_ir.undefined
+  py_ir.storevar "foo" %1 : !py_ir.undefined
+  %2 = py_ir.loadvar "foo" : !py_ir.undefined
+  %3 = py_ir.call %2 : !py_ir.undefined  () -> !py_ir.undefined
 }


### PR DESCRIPTION
* Remove hardcoded `%2` and functions name from checks.
* Simplifies test IR removing extra constants
While test code:
```python
def foo():
    while A:
        A = A + 1

foo()
```