### PR TITLE
Add canonicalization for PyIR.PyFuncOp

### DIFF
--- a/newlang/hckernel/mlir/include/hc/Dialect/PyIR/IR/PyIROps.td
+++ b/newlang/hckernel/mlir/include/hc/Dialect/PyIR/IR/PyIROps.td
@@ -219,6 +219,7 @@ def PyIR_PyFuncOp : PyIR_OpBase<"func", [Pure, AttrSizedOperandSegments]> {
   }];
 
   let skipDefaultBuilders = 1;
+  let hasCanonicalizer = 1;
 
   let assemblyFormat = [{
     attr-dict $name

--- a/newlang/hckernel/mlir/lib/Dialect/PyIR/IR/PyIROps.cpp
+++ b/newlang/hckernel/mlir/lib/Dialect/PyIR/IR/PyIROps.cpp
@@ -65,8 +65,8 @@ public:
     rewriter.modifyOpInPlace(op, [&] {
       auto *entryBlock = op.getEntryBlock();
       auto allArgs = entryBlock->getArguments().size();
-      auto captNames = mlir::SmallVector<mlir::Attribute>(
-          op.getCaptureNames().getAsRange<mlir::Attribute>());
+      auto captNames =
+          llvm::to_vector(op.getCaptureNames().getAsRange<mlir::Attribute>());
 
       unsigned numArgs = op.getBlockArgs().size();
       mlir::BitVector toErase(allArgs);

--- a/newlang/hckernel/mlir/lib/Dialect/PyIR/IR/PyIROps.cpp
+++ b/newlang/hckernel/mlir/lib/Dialect/PyIR/IR/PyIROps.cpp
@@ -33,6 +33,61 @@ void hc::py_ir::LoadModuleOp::getTypingKeyArgs(
   args.emplace_back(getNameAttr());
 }
 
+namespace {
+
+struct CleanupUnusedCaptures final
+    : public mlir::OpRewritePattern<hc::py_ir::PyFuncOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(hc::py_ir::PyFuncOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto capturesBlockArgs = op.getCaptureBlockArgs();
+    auto captureNames = op.getCaptureNames();
+
+    bool hasUnused = false;
+    for (auto &&arg : capturesBlockArgs) {
+      if (arg.use_empty()) {
+        hasUnused = true;
+        break;
+      }
+    }
+
+    if (!hasUnused)
+      return mlir::failure();
+
+    mlir::SmallVector<unsigned> indexes;
+    for (int i = captureNames.size() - 1; i >= 0; --i) {
+      auto capt = capturesBlockArgs[i];
+      if (capt.use_empty()) {
+        indexes.push_back(i);
+      }
+    }
+
+    auto eraseCaptureByIndex = [&](unsigned idx) {
+      int blockArgIdx = idx + op.getBlockArgs().size();
+      auto *entryBlock = op.getEntryBlock();
+      op.getCaptureArgsMutable().erase(idx);
+      auto captNames = mlir::SmallVector<mlir::Attribute>(
+          op.getCaptureNames().getAsRange<mlir::Attribute>());
+      captNames.erase(captNames.begin() + idx);
+      auto attr =
+          rewriter.getArrayAttr(mlir::ArrayRef<mlir::Attribute>(captNames));
+      op.setCaptureNamesAttr(attr);
+      entryBlock->eraseArgument(blockArgIdx);
+    };
+
+    for (auto &&idx : indexes) {
+      eraseCaptureByIndex(idx);
+    }
+
+    return mlir::success();
+  }
+};
+
+} // namespace
+
 mlir::OpFoldResult hc::py_ir::ConstantOp::fold(FoldAdaptor /*adaptor*/) {
   return getValue();
 }
@@ -146,6 +201,11 @@ static void printArgList(mlir::OpAsmPrinter &printer, Op /*op*/,
     printer.printOperand(arg);
   }
   printer << ')';
+}
+
+void hc::py_ir::PyFuncOp::getCanonicalizationPatterns(
+    ::mlir::RewritePatternSet &results, ::mlir::MLIRContext *context) {
+  results.insert<CleanupUnusedCaptures>(context);
 }
 
 #include "hc/Dialect/PyIR/IR/PyIROpsDialect.cpp.inc"

--- a/newlang/hckernel/tests/Dialect/PyIR/canonicalization.mlir
+++ b/newlang/hckernel/tests/Dialect/PyIR/canonicalization.mlir
@@ -1,0 +1,163 @@
+
+// RUN: hc-opt -allow-unregistered-dialect %s -pass-pipeline='builtin.module(py_ir.module(canonicalize{test-convergence}))' -split-input-file | FileCheck %s
+
+// CHECK-LABEL: py_ir.module {
+//       CHECK: py_ir.func "func" (a:%[[A:.*]], b:%[[A]]) : !py_ir.undefined, !py_ir.undefined capture (c:%[[C:.*]], d:%[[D:.*]], e:%[[E:.*]])
+//       CHECK: ^bb0(%[[ARG0:.*]]: !py_ir.undefined, %[[ARG1:.*]]: !py_ir.undefined, %[[ARG2:.*]]: !py_ir.undefined, %[[ARG3:.*]]: !py_ir.undefined, %[[ARG4:.*]]: !py_ir.undefined):
+//       CHECK: py_ir.tuple_pack %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]], %[[ARG4]] : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+//       CHECK: py_ir.module_end
+py_ir.module {
+  %0 = py_ir.empty_annotation
+  %1 = typing.make_ident "i1" []
+  %2 = typing.make_ident "i8" []
+  %3 = typing.make_ident "i16" []
+  %4 = py_ir.func "func" (a:%0, b:%0) : !py_ir.undefined, !py_ir.undefined capture (c:%1, d:%2, e:%3) : !typing.value, !typing.value, !typing.value -> !py_ir.undefined {
+  ^bb0(%arg0: !py_ir.undefined, %arg1: !py_ir.undefined, %arg2: !py_ir.undefined, %arg3: !py_ir.undefined, %arg4: !py_ir.undefined):
+    %5 = py_ir.tuple_pack %arg0, %arg1, %arg2, %arg3, %arg4 : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+    py_ir.return %5 : !py_ir.undefined
+  }
+  py_ir.module_end %4 : !py_ir.undefined
+}
+
+// -----
+
+// CHECK-LABEL: py_ir.module {
+//       CHECK: py_ir.func "func" (a:%[[A:.*]], b:%[[A]]) : !py_ir.undefined, !py_ir.undefined capture (c:%[[C:.*]], d:%[[D:.*]], e:%[[E:.*]])
+//       CHECK: ^bb0(%[[ARG0:.*]]: !py_ir.undefined, %[[ARG1:.*]]: !py_ir.undefined, %[[ARG2:.*]]: !py_ir.undefined, %[[ARG3:.*]]: !py_ir.undefined, %[[ARG4:.*]]: !py_ir.undefined):
+//       CHECK: py_ir.tuple_pack %[[ARG0]], %[[ARG2]], %[[ARG3]], %[[ARG4]] : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+//       CHECK: py_ir.module_end
+py_ir.module {
+  %0 = py_ir.empty_annotation
+  %1 = typing.make_ident "i1" []
+  %2 = typing.make_ident "i8" []
+  %3 = typing.make_ident "i16" []
+  %4 = py_ir.func "func" (a:%0, b:%0) : !py_ir.undefined, !py_ir.undefined capture (c:%1, d:%2, e:%3) : !typing.value, !typing.value, !typing.value -> !py_ir.undefined {
+  ^bb0(%arg0: !py_ir.undefined, %arg1: !py_ir.undefined, %arg2: !py_ir.undefined, %arg3: !py_ir.undefined, %arg4: !py_ir.undefined):
+    %5 = py_ir.tuple_pack %arg0, %arg2, %arg3, %arg4 : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+    py_ir.return %5 : !py_ir.undefined
+  }
+  py_ir.module_end %4 : !py_ir.undefined
+}
+
+// -----
+
+// CHECK-LABEL: py_ir.module {
+//       CHECK: %{{.*}} = py_ir.func "func" (a:%[[A:.*]], b:%[[A]]) : !py_ir.undefined, !py_ir.undefined capture (c:%[[C:.*]], d:%[[D:.*]])
+//       CHECK: ^bb0(%[[ARG0:.*]]: !py_ir.undefined, %[[ARG1:.*]]: !py_ir.undefined, %[[ARG2:.*]]: !py_ir.undefined, %[[ARG3:.*]]: !py_ir.undefined):
+//       CHECK: %{{.*}} = py_ir.tuple_pack %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]] : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+//       CHECK: py_ir.return
+//       CHECK: py_ir.module_end
+py_ir.module {
+  %0 = py_ir.empty_annotation
+  %1 = typing.make_ident "i1" []
+  %2 = typing.make_ident "i8" []
+  %3 = typing.make_ident "i16" []
+  %4 = py_ir.func "func" (a:%0, b:%0) : !py_ir.undefined, !py_ir.undefined capture (c:%1, d:%2, e:%3) : !typing.value, !typing.value, !typing.value -> !py_ir.undefined {
+  ^bb0(%arg0: !py_ir.undefined, %arg1: !py_ir.undefined, %arg2: !py_ir.undefined, %arg3: !py_ir.undefined, %arg4: !py_ir.undefined):
+    %5 = py_ir.tuple_pack %arg0, %arg1, %arg2, %arg3 : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+    py_ir.return %5 : !py_ir.undefined
+  }
+  py_ir.module_end %4 : !py_ir.undefined
+}
+
+// -----
+
+// CHECK-LABEL: py_ir.module {
+//       CHECK: py_ir.func "func" (a:%[[A:.*]], b:%[[A]]) : !py_ir.undefined, !py_ir.undefined capture (c:%[[C:.*]], e:%[[E:.*]])
+//       CHECK: ^bb0(%[[ARG0:.*]]: !py_ir.undefined, %[[ARG1:.*]]: !py_ir.undefined, %[[ARG2:.*]]: !py_ir.undefined, %[[ARG4:.*]]: !py_ir.undefined):
+//       CHECK: py_ir.tuple_pack %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG4]] : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+//       CHECK: py_ir.module_end
+py_ir.module {
+  %0 = py_ir.empty_annotation
+  %1 = typing.make_ident "i1" []
+  %2 = typing.make_ident "i8" []
+  %3 = typing.make_ident "i16" []
+  %4 = py_ir.func "func" (a:%0, b:%0) : !py_ir.undefined, !py_ir.undefined capture (c:%1, d:%2, e:%3) : !typing.value, !typing.value, !typing.value -> !py_ir.undefined {
+  ^bb0(%arg0: !py_ir.undefined, %arg1: !py_ir.undefined, %arg2: !py_ir.undefined, %arg3: !py_ir.undefined, %arg4: !py_ir.undefined):
+    %5 = py_ir.tuple_pack %arg0, %arg1, %arg2, %arg4 : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+    py_ir.return %5 : !py_ir.undefined
+  }
+  py_ir.module_end %4 : !py_ir.undefined
+}
+
+// -----
+
+// CHECK-LABEL: py_ir.module {
+//       CHECK: py_ir.func "func" (a:%[[A:.*]], b:%[[A]]) : !py_ir.undefined, !py_ir.undefined capture (d:%[[D:.*]], e:%[[E:.*]])
+//       CHECK: ^bb0(%[[ARG0:.*]]: !py_ir.undefined, %[[ARG1:.*]]: !py_ir.undefined, %[[ARG3:.*]]: !py_ir.undefined, %[[ARG4:.*]]: !py_ir.undefined):
+//       CHECK: py_ir.tuple_pack %[[ARG0]], %[[ARG1]], %[[ARG3]], %[[ARG4]] : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+//       CHECK: py_ir.module_end
+py_ir.module {
+  %0 = py_ir.empty_annotation
+  %1 = typing.make_ident "i1" []
+  %2 = typing.make_ident "i8" []
+  %3 = typing.make_ident "i16" []
+  %4 = py_ir.func "func" (a:%0, b:%0) : !py_ir.undefined, !py_ir.undefined capture (c:%1, d:%2, e:%3) : !typing.value, !typing.value, !typing.value -> !py_ir.undefined {
+  ^bb0(%arg0: !py_ir.undefined, %arg1: !py_ir.undefined, %arg2: !py_ir.undefined, %arg3: !py_ir.undefined, %arg4: !py_ir.undefined):
+    %5 = py_ir.tuple_pack %arg0, %arg1, %arg3, %arg4 : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+    py_ir.return %5 : !py_ir.undefined
+  }
+  py_ir.module_end %4 : !py_ir.undefined
+}
+
+// -----
+
+// CHECK-LABEL: py_ir.module {
+//       CHECK: py_ir.func "func" (a:%[[A:.*]], b:%[[A]]) : !py_ir.undefined, !py_ir.undefined capture (c:%[[C:.*]])
+//       CHECK: ^bb0(%[[ARG0:.*]]: !py_ir.undefined, %[[ARG1:.*]]: !py_ir.undefined, %[[ARG2:.*]]: !py_ir.undefined):
+//       CHECK: py_ir.tuple_pack %[[ARG0]], %[[ARG1]], %[[ARG2]] : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+//       CHECK: py_ir.module_end
+py_ir.module {
+  %0 = py_ir.empty_annotation
+  %1 = typing.make_ident "i1" []
+  %2 = typing.make_ident "i8" []
+  %3 = typing.make_ident "i16" []
+  %4 = py_ir.func "func" (a:%0, b:%0) : !py_ir.undefined, !py_ir.undefined capture (c:%1, d:%2, e:%3) : !typing.value, !typing.value, !typing.value -> !py_ir.undefined {
+  ^bb0(%arg0: !py_ir.undefined, %arg1: !py_ir.undefined, %arg2: !py_ir.undefined, %arg3: !py_ir.undefined, %arg4: !py_ir.undefined):
+    %5 = py_ir.tuple_pack %arg0, %arg1, %arg2 : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+    py_ir.return %5 : !py_ir.undefined
+  }
+  py_ir.module_end %4 : !py_ir.undefined
+}
+
+// -----
+
+// CHECK-LABEL: py_ir.module {
+//       CHECK: py_ir.func "func" (a:%[[A:.*]], b:%[[A]]) : !py_ir.undefined, !py_ir.undefined capture (e:%[[E:.*]])
+//       CHECK: ^bb0(%[[ARG0:.*]]: !py_ir.undefined, %[[ARG1:.*]]: !py_ir.undefined, %[[ARG4:.*]]: !py_ir.undefined):
+//       CHECK: py_ir.tuple_pack %[[ARG0]], %[[ARG1]], %[[ARG4]] : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+//       CHECK: py_ir.module_end
+py_ir.module {
+  %0 = py_ir.empty_annotation
+  %1 = typing.make_ident "i1" []
+  %2 = typing.make_ident "i8" []
+  %3 = typing.make_ident "i16" []
+  %4 = py_ir.func "func" (a:%0, b:%0) : !py_ir.undefined, !py_ir.undefined capture (c:%1, d:%2, e:%3) : !typing.value, !typing.value, !typing.value -> !py_ir.undefined {
+  ^bb0(%arg0: !py_ir.undefined, %arg1: !py_ir.undefined, %arg2: !py_ir.undefined, %arg3: !py_ir.undefined, %arg4: !py_ir.undefined):
+    %5 = py_ir.tuple_pack %arg0, %arg1, %arg4 : !py_ir.undefined, !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+    py_ir.return %5 : !py_ir.undefined
+  }
+  py_ir.module_end %4 : !py_ir.undefined
+}
+
+// -----
+
+// CHECK-LABEL: py_ir.module {
+//       CHECK: py_ir.func "func" (a:%[[A:.*]], b:%[[A]]) : !py_ir.undefined, !py_ir.undefined capture ()
+//       CHECK: ^bb0(%[[ARG0:.*]]: !py_ir.undefined, %[[ARG1:.*]]: !py_ir.undefined):
+//       CHECK: py_ir.tuple_pack %[[ARG0]], %[[ARG1]] : !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+//       CHECK: py_ir.module_end
+py_ir.module {
+  %0 = py_ir.empty_annotation
+  %1 = typing.make_ident "i1" []
+  %2 = typing.make_ident "i8" []
+  %3 = typing.make_ident "i16" []
+  %4 = py_ir.func "func" (a:%0, b:%0) : !py_ir.undefined, !py_ir.undefined capture (c:%1, d:%2, e:%3) : !typing.value, !typing.value, !typing.value -> !py_ir.undefined {
+  ^bb0(%arg0: !py_ir.undefined, %arg1: !py_ir.undefined, %arg2: !py_ir.undefined, %arg3: !py_ir.undefined, %arg4: !py_ir.undefined):
+    %5 = py_ir.tuple_pack %arg0, %arg1 : !py_ir.undefined, !py_ir.undefined -> !py_ir.undefined
+    py_ir.return %5 : !py_ir.undefined
+  }
+  py_ir.module_end %4 : !py_ir.undefined
+}
+
+// -----

--- a/newlang/hckernel/tests/Dialect/PyIR/canonicalization.mlir
+++ b/newlang/hckernel/tests/Dialect/PyIR/canonicalization.mlir
@@ -159,5 +159,3 @@ py_ir.module {
   }
   py_ir.module_end %4 : !py_ir.undefined
 }
-
-// -----


### PR DESCRIPTION
Add canonicalization for PyIR.PyFuncOp which eliminates unused captures.